### PR TITLE
Update .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,6 +3,13 @@
 
 version: 2
 
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+    # Specify other tools if needed
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
     configuration: docs/conf.py
@@ -14,8 +21,7 @@ sphinx:
 # # Optionally build your docs in additional formats such as PDF and ePub
 # formats: all
 
-# Optionally set the version of Python and requirements required to build your docs
+# Declare the Python requirements required to build your documentation
 python:
-    version: 3.8
-    install:
-        - requirements: docs/requirements.txt
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
The build key in .readthedocs.yml was missing and seems to be required now (https://docs.readthedocs.io/en/stable/config-file/v2.html). Building the docs should not fail anymore now.
